### PR TITLE
iptsd-2-r1.ebuild add build dependencies media-libs/libsdl2 and dev-cpp/eigen

### DIFF
--- a/sys-firmware/iptsd/iptsd-2-r1.ebuild
+++ b/sys-firmware/iptsd/iptsd-2-r1.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 
 DEPEND="dev-libs/hidapi dev-cpp/cli11 dev-libs/spdlog dev-cpp/ms-gsl dev-libs/inih"
 RDEPEND="${DEPEND}"
-BDEPEND="dev-build/ninja sys-devel/gcc dev-build/meson"
+BDEPEND="dev-build/ninja sys-devel/gcc dev-build/meson media-libs/libsdl2 dev-cpp/eigen"
 
 src_configure() {
 	meson_src_configure


### PR DESCRIPTION

emerging iptsd from this overlay resulted in failure; i checked the build logs and it was a result of missing eigen and libsdl2. i added them here.

according to iptsd's github https://github.com/linux-surface/iptsd these two packages are build dependencies, so i added them to the build dependency line. i didn't actually verify this as correct; i expected that iptsd knew best.

i also didn't test; i manually installed eigen and libsdl2 and then re-emerged iptsd and it appeared to have installed happily. if you want, i can un-emerge each of those, then try my forked overlay and see if it installs properly. but i was hoping it's a minimal enough change that that might not be necessary.

i haven't gotten iptsd working yet; i'm using systemd and it's failing because iptsd is missing the argument "DEVICE FILE REQUIRED" (that's actually its name in `iptsd --help` output), so that's the next todo item in giving this old tablet new life :)
